### PR TITLE
Setup CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+sudo: false
+language: erlang
+otp_release: 20.2
+script: rebar3 do eunit, dialyzer

--- a/src/euri.erl
+++ b/src/euri.erl
@@ -29,10 +29,10 @@
 
 -type nonempty_binary() :: <<_:8, _:_*8>>.
 
--type query() ::[ { atom() | nonempty_string() | nonempty_binary()
-                  , boolean() | integer() | string() | nonempty_binary()
-                  }
-                ]
+-type query() :: [ { atom() | nonempty_string() | nonempty_binary()
+                   , boolean() | integer() | string() | nonempty_binary()
+                   }
+                 ].
 
 -type args() :: #{ scheme => nonempty_string() | nonempty_binary()
                  , host => nonempty_string() | nonempty_binary()


### PR DESCRIPTION
By enabling CI, we can prevent silly things like missing a `.` in a typespec.