### PR TITLE
Format and remove usage of http_uri:encode/1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on: push
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        erl: [21, 22, 23]
+
+    container:
+      image: erlang:${{ matrix.erl }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run tests
+      run: rebar3 eunit
+    - name: Run dialyzer
+      run: rebar3 dialyzer
+    - name: Run formatting check
+      run: rebar3 format --verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-sudo: false
-language: erlang
-otp_release: 20.2
-script: rebar3 do eunit, dialyzer

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
 %% -*- mode: erlang -*-
+{erl_opts, [debug_info, warnings_as_errors]}.
 
-{erl_opts, [ debug_info
-           , warnings_as_errors
-           ]
-}.
+{plugins, [{tqformat, "0.1.2"}]}.
+
+{tqformat, [{files, ["{src}/*.{hrl,erl,app.src}", "rebar.config"]}, {width, 96}]}.
 
 {deps, []}.

--- a/src/euri.app.src
+++ b/src/euri.app.src
@@ -1,16 +1,12 @@
 { application
-, euri,
- [ {description, "An Erlang library for constructing URIs"}
- , {vsn, "0.9.4"}
- , {modules, []}
- , {registered, []},
-   {applications, [ kernel
-                  , stdlib
-                  , inets
-                  ]
-   }
- , {env,[]}
- , {licenses, ["https://github.com/truqu/euri/blob/develop/LICENSE"]}
- , {links, [{"GitHub", "https://github.com/truqu/euri"}]}
- ]
+, euri
+, [ {description, "An Erlang library for constructing URIs"}
+  , {vsn, "0.9.4"}
+  , {modules, []}
+  , {registered, []}
+  , {applications, [kernel, stdlib, inets]}
+  , {env, []}
+  , {licenses, ["https://github.com/truqu/euri/blob/develop/LICENSE"]}
+  , {links, [{"GitHub", "https://github.com/truqu/euri"}]}
+  ]
 }.

--- a/src/euri.erl
+++ b/src/euri.erl
@@ -1,18 +1,13 @@
 -module(euri).
 
 -ifdef(TEST).
+
 -include_lib("eunit/include/eunit.hrl").
+
 -endif.
 
 %% API exports
--export([ new/0
-        , new/1
-        , to_string/1
-        , to_string/2
-        , to_binary/1
-        , to_binary/2
-        ]
-       ).
+-export([new/0, new/1, to_string/1, to_string/2, to_binary/1, to_binary/2]).
 
 %% Record, type, and macro definitions
 -record( uri
@@ -28,36 +23,24 @@
 -opaque uri() :: #uri{}.
 
 -type nonempty_binary() :: <<_:8, _:_*8>>.
-
 -type path() :: string() | binary() | [nonempty_string() | nonempty_binary()].
-
--type query() :: [ { Key :: atom() | nonempty_string() | nonempty_binary()
-                   , Value :: boolean() | integer() | string() | nonempty_binary()
-                   }
-                 ].
-
+-type query() :: [{ Key :: atom() | nonempty_string() | nonempty_binary()
+                  , Value :: boolean() | integer() | string() | nonempty_binary()
+                  }].
 -type args() :: #{ scheme => nonempty_string() | nonempty_binary()
                  , host => nonempty_string() | nonempty_binary()
                  , port => non_neg_integer()
                  , path => path()
                  , query => query()
                  }.
-
 -type option() :: relative.
 
 %% Type exports
--export_type([ uri/0
-             , args/0
-             , nonempty_binary/0
-             , query/0
-             , path/0
-             , option/0
-             ]).
+-export_type([uri/0, args/0, nonempty_binary/0, query/0, path/0, option/0]).
 
 %%%-----------------------------------------------------------------------------
 %%% API functions
 %%%-----------------------------------------------------------------------------
-
 %% @doc Create a new, "empty" URI.
 %%
 %% This will default to an uri pointing to `https://localhost'. In other words,
@@ -65,9 +48,9 @@
 %% and both the path and the query will be left empty.
 %%
 %% This is equivalent to calling `euri:new(#{})'.
+
 -spec new() -> uri().
-new() ->
-  new(#{}).
+new() -> new(#{}).
 
 %% @doc Create a URI from {@type args()}.
 %%
@@ -75,6 +58,7 @@ new() ->
 %% defaults will be used: `scheme' defaults to `https', `host' defaults to
 %% `localhost', `port' to `443' and the `path' and `query' are left empty when
 %% not supplied.
+
 -spec new(args()) -> uri().
 new(Args) ->
   %% Get path
@@ -83,25 +67,26 @@ new(Args) ->
   Scheme = to_l(maps:get(scheme, Args, "https")),
   #uri{ scheme = Scheme
       , host = to_l(maps:get(host, Args, "localhost"))
-      , port = maps:get(port, Args, case Scheme of
-                                      "http"  -> 80;
-                                      "https" -> 443
-                                    end
+      , port = maps:get( port
+                       , Args
+                       , case Scheme of
+                           "http" -> 80;
+                           "https" -> 443
+                         end
                        )
       , path_segments = case is_list_of_lists(Path) of
-                          true  -> Path;
+                          true -> Path;
                           false ->
                             case is_list_with_binary(Path) of
-                              true  -> lists:map(fun to_l/1, Path);
+                              true -> lists:map(fun to_l/1, Path);
                               false -> string:tokens(to_l(Path), "/")
                             end
                         end
       , query = [{to_l(K), b_to_l(V)} || {K, V} <- maps:get(query, Args, [])]
-      , trailing_slash =
-          case is_list_of_lists(Path) of
-            true  -> false;
-            false -> match == re:run(Path, "/$", [{capture, none}])
-          end
+      , trailing_slash = case is_list_of_lists(Path) of
+                           true -> false;
+                           false -> match == re:run(Path, "/$", [{capture, none}])
+                         end
       }.
 
 %% @doc Turn a {@type uri()} into a `string()'.
@@ -118,104 +103,125 @@ new(Args) ->
 %% '''
 %%
 %% This is equivalent to calling `euri:to_string(Uri, [])'.
+
 -spec to_string(uri()) -> nonempty_string().
-to_string(U) ->
-  to_string(U, []).
+to_string(U) -> to_string(U, []).
 
 %% @doc Turn a {@type uri()} into a `string()' with some options.
 %%
 %% Currently, the only {@type option()} is `relative' which will make this
 %% function return an URL relative to the root of the hostname.
+
 -spec to_string(uri(), [option()]) -> nonempty_string().
 to_string(U, Opts) ->
   Relative = lists:member(relative, Opts),
-  lists:flatten(
-    [ %% Scheme, host, and port
-      if
-        Relative ->
-          [];
-        true ->
-          [ U#uri.scheme, "://", U#uri.host
-          , case U#uri.port of
-              80  -> [];
-              443 -> [];
-              P   -> [":", integer_to_list(P)]
-            end
-          ]
-      end
-      %% Path
-    , case {U#uri.path_segments, Relative} of
-        {[], false} ->
-          "";
-        {[], true} ->
-          "/";
-        {_, _} ->
-          [ "/"
-          , string:join([http_uri:encode(P) || P <- U#uri.path_segments] , "/")
-          ]
-      end
-    , if
-        U#uri.trailing_slash -> "/";
-        true                 -> ""
-      end
-      %% Query
-    , case U#uri.query of
-        [] -> [];
-        Q  -> [$?, encode_query(Q)]
-      end
-    ]
-   ).
+  %% Scheme, host, and port
+  lists:flatten([ if
+                    Relative -> [];
+                    true ->
+                      [ U#uri.scheme
+                      , "://"
+                      , U#uri.host
+                      , case U#uri.port of
+                          80 -> [];
+                          443 -> [];
+                          P -> [":", integer_to_list(P)]
+                        end
+                      ]
+                  end
+                , %% Path
+                  case {U#uri.path_segments, Relative} of
+                    {[], false} -> "";
+                    {[], true} -> "/";
+                    {_, _} ->
+                      [ "/"
+                      , string:join([html5_byte_encode(P) || P <- U#uri.path_segments], "/")
+                      ]
+                  end
+                , if
+                    U#uri.trailing_slash -> "/";
+                    true -> ""
+                  end
+                , %% Query
+                  case U#uri.query of
+                    [] -> [];
+                    Q -> [$?, encode_query(Q)]
+                  end
+                ]).
 
 %% @doc Same as {@link to_string/1} but returns a `binary()'.
 -spec to_binary(uri()) -> nonempty_binary().
-to_binary(U) ->
-  to_binary(U, []).
+to_binary(U) -> to_binary(U, []).
 
 %% @doc Same as {@link to_string/2} but returns a `binary()'.
 -spec to_binary(uri(), [option()]) -> nonempty_binary().
-to_binary(U, Opts) ->
-  list_to_binary(to_string(U, Opts)).
+to_binary(U, Opts) -> list_to_binary(to_string(U, Opts)).
 
 %%%-----------------------------------------------------------------------------
 %%% Internal functions
 %%%-----------------------------------------------------------------------------
 
-to_l(V) when is_binary(V) ->
-  erlang:binary_to_list(V);
-to_l(V) when is_atom(V) ->
-  erlang:atom_to_list(V);
-to_l(V) ->
-  V.
+to_l(V) when is_binary(V) -> erlang:binary_to_list(V);
+to_l(V) when is_atom(V) -> erlang:atom_to_list(V);
+to_l(V) -> V.
 
-b_to_l(V) when is_binary(V) ->
-  erlang:binary_to_list(V);
-b_to_l(V) ->
-  V.
+b_to_l(V) when is_binary(V) -> erlang:binary_to_list(V);
+b_to_l(V) -> V.
 
-encode_query(Q) ->
-  intersperse($&, [encode_query_param(K, V) || {K, V} <- Q, V /= false]).
+encode_query(Q) -> intersperse($&, [encode_query_param(K, V) || {K, V} <- Q, V /= false]).
 
-encode_query_param(K, true) ->
-  [http_uri:encode(K)];
-encode_query_param(K, V) when is_integer(V) ->
-  [http_uri:encode(K), "=", integer_to_list(V)];
-encode_query_param(K, V) when is_list(V) ->
-  [http_uri:encode(K), "=", http_uri:encode(V)].
+encode_query_param(K, true) -> [html5_byte_encode(K)];
+encode_query_param(K, V) when is_integer(V) -> [html5_byte_encode(K), "=", integer_to_list(V)];
+encode_query_param(K, V) when is_list(V) -> [html5_byte_encode(K), "=", html5_byte_encode(V)].
 
-intersperse(_S, L = [_]) ->
-  L;
-intersperse(S, [X | Xs]) ->
-  [X, S | intersperse(S, Xs)].
+intersperse(_S, L = [_]) -> L;
+intersperse(S, [X | Xs]) -> [X, S | intersperse(S, Xs)].
 
-is_list_of_lists(L) when is_list(L) ->
-  lists:all(fun (X) -> erlang:is_list(X) end, L);
-is_list_of_lists(_) ->
-  false.
+is_list_of_lists(L) when is_list(L) -> lists:all(fun (X) -> erlang:is_list(X) end, L);
+is_list_of_lists(_) -> false.
 
-is_list_with_binary(L) when is_list(L) ->
-  lists:any(fun (X) -> erlang:is_binary(X) end, L);
-is_list_with_binary(_) ->
-  false.
+is_list_with_binary(L) when is_list(L) -> lists:any(fun (X) -> erlang:is_binary(X) end, L);
+is_list_with_binary(_) -> false.
+
+-define( DEC2HEX(X)
+       , if
+           ((X) >= 0) andalso ((X) =< 9) -> (X) + $0;
+           ((X) >= 10) andalso ((X) =< 15) -> (X) + $A - 10
+         end
+       ).
+
+html5_byte_encode(B) when is_list(B) -> html5_byte_encode(list_to_binary(B));
+html5_byte_encode(B) -> html5_byte_encode(B, <<>>).
+
+html5_byte_encode(<<>>, Acc) -> binary_to_list(Acc);
+html5_byte_encode(<<$\s, T/binary>>, Acc) -> html5_byte_encode(T, <<Acc/binary, "%20">>);
+html5_byte_encode(<<H, T/binary>>, Acc) ->
+  case is_url_char(H) of
+    true -> html5_byte_encode(T, <<Acc/binary, H>>);
+    false ->
+      <<A:4, B:4>> = <<H>>,
+      html5_byte_encode(T, <<Acc/binary, $%, (?DEC2HEX(A)), (?DEC2HEX(B))>>)
+  end;
+html5_byte_encode(H, _Acc) -> throw({error, invalid_input, H}).
+
+%% Return true if input char can appear in form-urlencoded string
+%% Allowed chararacters:
+%%   0x2A, 0x2D, 0x2E, 0x30 to 0x39, 0x41 to 0x5A,
+%%   0x5F, 0x61 to 0x7A
+
+is_url_char(C) when
+    C =:= 16#2A;
+    C =:= 16#2D;
+    C =:= 16#2E;
+    C =:= 16#5F;
+    16#30 =< C,
+    C =< 16#39;
+    16#41 =< C,
+    C =< 16#5A;
+    16#61 =< C,
+    C =< 16#7A ->
+  true;
+is_url_char(_) -> false.
 
 %%%-----------------------------------------------------------------------------
 %%% Tests


### PR DESCRIPTION
Rather, we inline selected parts of `uri_string` and use those.