### PR TITLE
Conditionally define `nonempty_binary/0` type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        erl: [21, 22, 23]
+        erl: [21, 22, 23, 24]
 
     container:
       image: erlang:${{ matrix.erl }}

--- a/src/euri.erl
+++ b/src/euri.erl
@@ -22,7 +22,13 @@
 
 -opaque uri() :: #uri{}.
 
+-if(?OTP_RELEASE < 24).
+
+%% From OTP 24 onwards, `nonempty_binary/0` is predefined
 -type nonempty_binary() :: <<_:8, _:_*8>>.
+
+-endif.
+
 -type path() :: string() | binary() | [nonempty_string() | nonempty_binary()].
 -type query() :: [{ Key :: atom() | nonempty_string() | nonempty_binary()
                   , Value :: boolean() | integer() | string() | nonempty_binary()


### PR DESCRIPTION
In OTP24, this is predefined and redefining produces a warning. This PR
also enabled OTP24 in CI.